### PR TITLE
Add /stats page

### DIFF
--- a/common.mts
+++ b/common.mts
@@ -1,13 +1,43 @@
 import type * as ws from 'ws';
 
 export const SERVER_PORT = 6970;
+export const STATS_FEED_PORT = 6971;
+export const AVERAGE_CAPACITY = 30;
 export const WORLD_FACTOR = 200;
 export const WORLD_WIDTH = 4*WORLD_FACTOR;
 export const WORLD_HEIGHT = 3*WORLD_FACTOR;
 export const PLAYER_SIZE = 30;
 export const PLAYER_SPEED = 500;
 
+export interface Counter {
+    kind: 'counter',
+    counter: number,
+    description: string,
+}
+
+export interface Average {
+    kind: 'average',
+    samples: Array<number>,
+    description: string
+}
+
+export interface Timer {
+    kind: 'timer',
+    startedAt: number,
+    description: string,
+}
+
+export type Stat = Counter | Average | Timer;
+export type Stats = {[key: string]: Stat}
+
 export type Direction = 'left' | 'right' | 'up' | 'down';
+
+// TODO: keeping the AVERAGE_CAPACITY checked relies on calling Stats.print() periodically.
+//   It would be better to go back to having a custom method for pushing samples
+export function average(xs: Array<number>): number {
+    while (xs.length > AVERAGE_CAPACITY) xs.shift();
+    return xs.reduce((a, b) => a + b, 0)/xs.length
+}
 
 type Moving = {
     [key in Direction]: boolean

--- a/common.mts
+++ b/common.mts
@@ -1,8 +1,7 @@
-import type * as ws from 'ws';
+import type * as ws from "ws";
 
 export const SERVER_PORT = 6970;
 export const STATS_FEED_PORT = 6971;
-export const AVERAGE_CAPACITY = 30;
 export const WORLD_FACTOR = 200;
 export const WORLD_WIDTH = 4*WORLD_FACTOR;
 export const WORLD_HEIGHT = 3*WORLD_FACTOR;
@@ -10,19 +9,19 @@ export const PLAYER_SIZE = 30;
 export const PLAYER_SPEED = 500;
 
 export interface Counter {
-    kind: 'counter',
+    kind: "counter",
     counter: number,
     description: string,
 }
 
 export interface Average {
-    kind: 'average',
+    kind: "average",
     samples: Array<number>,
     description: string
 }
 
 export interface Timer {
-    kind: 'timer',
+    kind: "timer",
     startedAt: number,
     description: string,
 }
@@ -30,14 +29,8 @@ export interface Timer {
 export type Stat = Counter | Average | Timer;
 export type Stats = {[key: string]: Stat}
 
-export type Direction = 'left' | 'right' | 'up' | 'down';
+export type Direction = "left" | "right" | "up" | "down";
 
-// TODO: keeping the AVERAGE_CAPACITY checked relies on calling Stats.print() periodically.
-//   It would be better to go back to having a custom method for pushing samples
-export function average(xs: Array<number>): number {
-    while (xs.length > AVERAGE_CAPACITY) xs.shift();
-    return xs.reduce((a, b) => a + b, 0)/xs.length
-}
 
 type Moving = {
     [key in Direction]: boolean
@@ -45,10 +38,10 @@ type Moving = {
 
 export type Vector2 = {x: number, y: number};
 export const DIRECTION_VECTORS: {[key in Direction]: Vector2} = {
-    'left':  {x: -1, y: 0},
-    'right': {x: 1, y: 0},
-    'up':    {x: 0, y: -1},
-    'down':  {x: 0, y: 1},
+    "left":  {x: -1, y: 0},
+    "right": {x: 1, y: 0},
+    "up":    {x: 0, y: -1},
+    "down":  {x: 0, y: 1},
 };
 
 function isDirection(arg: any): arg is Direction {
@@ -64,15 +57,15 @@ export interface Player {
 }
 
 export function isNumber(arg: any): arg is number {
-    return typeof(arg) === 'number';
+    return typeof(arg) === "number";
 }
 
 export function isString(arg: any): arg is string {
-    return typeof(arg) === 'string';
+    return typeof(arg) === "string";
 }
 
 export function isBoolean(arg: any): arg is boolean {
-    return typeof(arg) === 'boolean';
+    return typeof(arg) === "boolean";
 }
 
 export interface Hello {
@@ -85,12 +78,12 @@ export interface Hello {
 
 export function isHello(arg: any): arg is Hello {
     return arg
-        && arg.kind === 'Hello'
+        && arg.kind === "Hello"
         && isNumber(arg.id);
 }
 
 export interface PlayerJoined {
-    kind: 'PlayerJoined',
+    kind: "PlayerJoined",
     id: number,
     x: number,
     y: number,
@@ -99,7 +92,7 @@ export interface PlayerJoined {
 
 export function isPlayerJoined(arg: any): arg is PlayerJoined {
     return arg
-        && arg.kind === 'PlayerJoined'
+        && arg.kind === "PlayerJoined"
         && isNumber(arg.id)
         && isNumber(arg.x)
         && isNumber(arg.y)
@@ -107,31 +100,31 @@ export function isPlayerJoined(arg: any): arg is PlayerJoined {
 }
 
 export interface PlayerLeft {
-    kind: 'PlayerLeft',
+    kind: "PlayerLeft",
     id: number,
 }
 
 export function isPlayerLeft(arg: any): arg is PlayerLeft {
     return arg
-        && arg.kind === 'PlayerLeft'
+        && arg.kind === "PlayerLeft"
         && isNumber(arg.id)
 }
 
 export interface AmmaMoving {
-    kind: 'AmmaMoving',
+    kind: "AmmaMoving",
     start: boolean,
     direction: Direction,
 }
 
 export function isAmmaMoving(arg: any): arg is AmmaMoving {
     return arg
-        && arg.kind === 'AmmaMoving'
+        && arg.kind === "AmmaMoving"
         && isBoolean(arg.start)
         && isDirection(arg.direction);
 }
 
 export interface PlayerMoving {
-    kind: 'PlayerMoving',
+    kind: "PlayerMoving",
     id: number,
     x: number,
     y: number,
@@ -141,7 +134,7 @@ export interface PlayerMoving {
 
 export function isPlayerMoving(arg: any): arg is PlayerMoving {
     return arg
-        && arg.kind === 'PlayerMoving'
+        && arg.kind === "PlayerMoving"
         && isNumber(arg.id)
         && isNumber(arg.x)
         && isNumber(arg.y)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "ws": "^8.18.0"
       },
       "devDependencies": {
+        "@types/plotly.js": "^2.33.0",
         "@types/ws": "^8.5.10",
         "http-server": "^14.1.1",
         "typescript": "^5.5.3"
@@ -25,6 +26,13 @@
       "dependencies": {
         "undici-types": "~5.26.4"
       }
+    },
+    "node_modules/@types/plotly.js": {
+      "version": "2.33.0",
+      "resolved": "https://registry.npmjs.org/@types/plotly.js/-/plotly.js-2.33.0.tgz",
+      "integrity": "sha512-oEyRCLLShp7lX4lRodFsigEv9z9OyL+UGWTKNdmpEghA3XR1CK+MjUPiIMf79625bvUvydOQ7kRx8cjCeG4Wvg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@types/plotly.js": "^2.33.0",
     "@types/ws": "^8.5.10",
     "http-server": "^14.1.1",
     "typescript": "^5.5.3"

--- a/server.mts
+++ b/server.mts
@@ -4,6 +4,7 @@ import {PlayerMoving, PlayerJoined, PlayerLeft, Player, Event, Hello, Direction}
 import http from "node:http";
 
 namespace Stats {
+    export const AVERAGE_CAPACITY = 30;
     const STATS_FEED_INTERVAL_MS = 2000;
     const stats: common.Stats = {}
 
@@ -30,7 +31,7 @@ namespace Stats {
     function getStat(stat: common.Stat): number {
         switch (stat.kind) {
             case 'counter': return stat.counter;
-            case 'average': return common.average(stat.samples);
+            case 'average': return average(stat.samples);
             case 'timer':   return performance.now() - stat.startedAt;
         }
     }
@@ -45,6 +46,13 @@ namespace Stats {
         for (let key in stats) {
             console.log(`  ${stats[key].description}`, getStat(stats[key]));
         }
+    }
+
+    // TODO: keeping the AVERAGE_CAPACITY checked relies on calling Stats.print() periodically.
+    //   It would be better to go back to having a custom method for pushing samples
+    function average(xs: Array<number>): number {
+        while (xs.length > AVERAGE_CAPACITY) xs.shift();
+        return xs.reduce((a, b) => a + b, 0)/xs.length
     }
 
     export const uptime               : common.Timer   = register("uptime",               {kind: 'timer', startedAt: 0, description: "Uptime (secs)"});

--- a/stats.html
+++ b/stats.html
@@ -9,11 +9,11 @@
     <script src="./stats.mjs" type="module"></script>
 </head>
 
-<body>
-    <h1>Stats feed</h1>
-    <div id="root">
-
-    </div>
+<body style="display:flex; flex-direction: column; align-items: center">
+    <h1 style="text-align:center">Stats feed</h1>
+    <div id="counter-chart" style="width: 100%; max-width: 1024px"></div>
+    <div id="average-chart" style="width: 100%; max-width: 1024px"></div>
+    <div id="timer-chart" style="width: 100%; max-width: 1024px"></div>
 </body>
 
 </html>

--- a/stats.html
+++ b/stats.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+    <script src="https://cdn.plot.ly/plotly-2.32.0.min.js" charset="utf-8"></script>
+    <script src="./stats.mjs" type="module"></script>
+</head>
+
+<body>
+    <h1>Stats feed</h1>
+    <div id="root">
+
+    </div>
+</body>
+
+</html>

--- a/stats.mts
+++ b/stats.mts
@@ -1,0 +1,58 @@
+import * as common from "./common.mjs";
+
+const $ = document.querySelector.bind(document);
+declare const Plotly: any //TODO: Add typings for this lib
+
+const source = new EventSource(
+    `http://${window.location.hostname}:${common.STATS_FEED_PORT}`,
+);
+const target = $("#root");
+if (!target) throw new Error("Event target element not found.");
+
+// Create the chart div
+const chartDiv = document.createElement("div");
+chartDiv.id = "chart";
+target.appendChild(chartDiv);
+
+// Initialize the chart
+Plotly.newPlot("chart", []);
+
+// Function to update the chart with the latest data
+function updateChart(data: common.Stats) {
+    // Create the chart data for each stat
+    const chartData = Object.keys(data).map((key) => {
+        const stat = data[key];
+        switch (stat.kind) {
+            case "counter":
+                return {
+                    x: [stat.description],
+                    y: [stat.counter],
+                    type: "bar",
+                    name: stat.description,
+                };
+            case "average":
+                return {
+                    x: [stat.description],
+                    y: [common.average(stat.samples)],
+                    type: "bar",
+                    name: stat.description,
+                };
+            case "timer":
+                return {
+                    x: [stat.description],
+                    y: [performance.now() - stat.startedAt],
+                    type: "bar",
+                    name: stat.description,
+                };
+        }
+    });
+
+    // Update the chart with the new data
+    Plotly.react("chart", chartData);
+}
+
+// Update the chart when new data is received
+source.addEventListener("message", (e) => {
+    const data = JSON.parse(e.data) as common.Stats;
+    updateChart(data);
+});


### PR DESCRIPTION
This PR will:

- Create a new HTTP Server inside Stats namespace.
- The server will respond any request with a response stream that push the current game stats every `STATS_FEED_INTERVAL_MS` configured as 2000 (ms) currently
- Create stats.html document that renders the stats (Currently a very basic implementation with 3 charts grouped by the stat kind)
- Move Stats types to ./common.mts
- Install `@types/plotly.js` as development dependency (for creating the charts) (types only because the stats.html uses a script tag pulling the lib from cdn)