### PR TITLE
Fix timers reported in milliseconds instead of seconds

### DIFF
--- a/server.mts
+++ b/server.mts
@@ -38,7 +38,7 @@ namespace Stats {
         switch (stat.kind) {
             case 'counter': return stat.counter;
             case 'average': return average(stat.samples);
-            case 'timer':   return performance.now() - stat.startedAt;
+            case 'timer':   return (performance.now() - stat.startedAt)/1000;
         }
     }
 


### PR DESCRIPTION
I'm also wondering if Timers should have a time scale associated with them / adapt to how much time has elapsed, like scale down to minutes if more than a minute has elapsed, but an hour hasn't yet, and etc..